### PR TITLE
Fixes build and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cache_store
 /bin/
 *.log
 i5validation.json
+src/main/jflex/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>groupId</groupId>
+    <groupId>de.ids_mannheim</groupId>
     <artifactId>KorAP-Tokenizer</artifactId>
     <version>2.2.2</version>
 
@@ -261,14 +261,10 @@
             <version>1.9.4</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>maven-surefire-common</artifactId>
-            <version>2.22.2</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.github.classgraph</groupId>

--- a/src/test/java/de/ids_mannheim/korap/tokenizer/TokenizerTest.java
+++ b/src/test/java/de/ids_mannheim/korap/tokenizer/TokenizerTest.java
@@ -2,8 +2,9 @@ package de.ids_mannheim.korap.tokenizer;
 
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayOutputStream;
+
 import opennlp.tools.util.Span;
-import org.apache.maven.surefire.shade.org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.Test;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
This PR addresses some minor issues with the build setup.

1. An **erroneous import** of `ByteArrayOuputStream` from  a 3rd-party library created a dependency on Maven Surefire. Changing the import to `java.io.ByteArrayOutputStream` removed the dependency and reduced the library dependency footprint when reusing it.
2. The **group identifier in the POM** was a placeholder; it has been changed to `de.ids_mannheim` so the library can be properly referred to in dependant projects.
3. **Generated sources** of the JFlex-based DFAs are added to `.gitignore`. 